### PR TITLE
Fix bug in PictureManager removal

### DIFF
--- a/js-and-algo/jesting-around/PictureManager.js
+++ b/js-and-algo/jesting-around/PictureManager.js
@@ -8,7 +8,10 @@ class PictureManager {
   }
 
   removePicture(picURL) {
-    this.pictureURLs.splice(this.pictureURLs.indexOf(picURL), 1);
+    const index = this.pictureURLs.indexOf(picURL);
+    if (index !== -1) {
+      this.pictureURLs.splice(index, 1);
+    }
   }
 }
 

--- a/js-and-algo/jesting-around/PictureManager.test.js
+++ b/js-and-algo/jesting-around/PictureManager.test.js
@@ -1,0 +1,33 @@
+const PM = require("./PictureManager");
+
+test("addPicture should add a picture URL to the pictureURLs array", function () {
+  //sanity
+  const picManager = new PM();
+  expect(picManager.pictureURLs.length).toBe(0);
+
+  picManager.addPicture("some_url");
+  expect(picManager.pictureURLs.length).toBe(1); //test
+  expect(picManager.pictureURLs).toContain("some_url"); //double check
+});
+
+test("removePicture should receive a picture URL and remove it from the pictureURLs array", function () {
+  //sanity
+  const picManager = new PM();
+  expect(picManager.pictureURLs.length).toBe(0);
+
+  picManager.addPicture("some_url");
+  picManager.addPicture("some_url2");
+  picManager.addPicture("some_url3");
+
+  picManager.removePicture("some_url2");
+  expect(picManager.pictureURLs.length).toBe(2);
+  expect(picManager.pictureURLs).not.toContain("some_url2"); //here this isn't double checking, this is necessary
+});
+
+test("removePicture should do nothing if URL does not exist", function () {
+  const picManager = new PM();
+  picManager.addPicture("url1");
+  picManager.addPicture("url2");
+  picManager.removePicture("missing_url");
+  expect(picManager.pictureURLs).toEqual(["url1", "url2"]);
+});


### PR DESCRIPTION
## Summary
- guard against removing wrong picture when URL doesn't exist
- enable PictureManager tests and cover missing URL case

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878906c75708325908ea16875d28833